### PR TITLE
feature/allow-pool-contract-address

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ export FD_CLI_WT_DB_PATH=/root/.flora/mainnet/wallet/db/blockchain_wallet_v1_mai
 
 # Set env var to launcher id of NFT plot.
 export LAUNCHER_HASH=aaa0cbae497933a6c029a3819759fe148829dfde0316cb0512ccad23edce6aaa
-# Set env var to pool_contract_puzzle_hash. 
-# This Bench32 decoded address of NFT plot, the one with comment "USE ONLY FOR PLOTTING".
-export CONTRACT_HASH=eeeeb79855585a0481e7cc5b653ed9720b894a2173dce927cce90eebfcd3f000
+# Set env var to pool_contract_address. 
+export POOL_CONTRACT_ADDRESS=xch13rht0xz4tpdqfq08e3dk20kewg9cjj3pw0wwjf7vay8whlxn7ppqapeqhz
 
 fd-cli nft-recover \
   -l "$LAUNCHER_HASH" \
-  -c "$CONTRACT_HASH" \
+  -p "$POOL_CONTRACT_ADDRESS" \
   -nh 127.0.0.1 \
   -np 18755 \
   -ct /root/.flora/mainnet/config/ssl/full_node/private_full_node.crt \

--- a/fd_cli/fd_cli.py
+++ b/fd_cli/fd_cli.py
@@ -143,8 +143,8 @@ def fd_cli_coin(
     type=str
 )
 @click.option(
-    '-c',
-    '--contract_hash',
+    '-p',
+    '--pool_contract_address',
     required=True,
     type=str
 )
@@ -183,7 +183,7 @@ def fd_cli_nft_recover(
         ctx: click.Context,
         delay: int,
         launcher_hash: str,
-        contract_hash: str,
+        pool_contract_address: str,
         node_host: str,
         node_port: int,
         cert_path: str,
@@ -194,7 +194,7 @@ def fd_cli_nft_recover(
         ctx=ctx,
         delay=delay,
         launcher_hash=launcher_hash,
-        contract_hash=contract_hash,
+        pool_contract_address=pool_contract_address,
         node_host=node_host,
         node_port=node_port,
         cert_path=cert_path,

--- a/fd_cli/fd_cli_cmd_nft_recover.py
+++ b/fd_cli/fd_cli_cmd_nft_recover.py
@@ -8,6 +8,10 @@ from chia.pools.pool_puzzles import (
     create_p2_singleton_puzzle
 )
 
+from chia.util.bech32m import (
+    decode_puzzle_hash
+)
+
 from chia.util.byte_types import (
     hexstr_to_bytes
 )
@@ -49,7 +53,7 @@ def fd_cli_cmd_nft_recover(
         ctx: click.Context,
         delay: int,
         launcher_hash: str,
-        contract_hash: str,
+        pool_contract_address: str,
         node_host: str,
         node_port: int,
         cert_path: str,
@@ -62,7 +66,7 @@ def fd_cli_cmd_nft_recover(
 
     delay_u64: uint64 = uint64(delay)
     launcher_hash_b32: bytes32 = bytes32(hexstr_to_bytes(launcher_hash))
-    contract_hash_b32: bytes32 = bytes32(hexstr_to_bytes(contract_hash))
+    contract_hash_b32: bytes32 = bytes32(hexstr_to_bytes(decode_puzzle_hash(pool_contract_address)))
 
     program_puzzle_hex: str = None
 

--- a/fd_cli/fd_cli_cmd_nft_recover.py
+++ b/fd_cli/fd_cli_cmd_nft_recover.py
@@ -66,7 +66,7 @@ def fd_cli_cmd_nft_recover(
 
     delay_u64: uint64 = uint64(delay)
     launcher_hash_b32: bytes32 = bytes32(hexstr_to_bytes(launcher_hash))
-    contract_hash_b32: bytes32 = bytes32(hexstr_to_bytes(decode_puzzle_hash(pool_contract_address)))
+    contract_hash_b32: bytes32 = bytes32(decode_puzzle_hash(pool_contract_address))
 
     program_puzzle_hex: str = None
 

--- a/fd_cli/fd_cli_cmd_nft_recover.py
+++ b/fd_cli/fd_cli_cmd_nft_recover.py
@@ -66,7 +66,7 @@ def fd_cli_cmd_nft_recover(
 
     delay_u64: uint64 = uint64(delay)
     launcher_hash_b32: bytes32 = bytes32(hexstr_to_bytes(launcher_hash))
-    contract_hash_b32: bytes32 = bytes32(decode_puzzle_hash(pool_contract_address))
+    contract_hash_b32: bytes32 = decode_puzzle_hash(pool_contract_address)
 
     program_puzzle_hex: str = None
 

--- a/fd_cli/fd_cli_cmd_nft_recover.py
+++ b/fd_cli/fd_cli_cmd_nft_recover.py
@@ -67,6 +67,7 @@ def fd_cli_cmd_nft_recover(
     delay_u64: uint64 = uint64(delay)
     launcher_hash_b32: bytes32 = bytes32(hexstr_to_bytes(launcher_hash))
     contract_hash_b32: bytes32 = decode_puzzle_hash(pool_contract_address)
+    contract_hash_hex: str = contract_hash_b32.hex()
 
     program_puzzle_hex: str = None
 
@@ -107,7 +108,7 @@ def fd_cli_cmd_nft_recover(
         f"FROM coin_record "
         f"WHERE spent == 0 "
         f"AND timestamp <= (strftime('%s', 'now') - {delay}) "
-        f"AND puzzle_hash LIKE '{contract_hash}' "
+        f"AND puzzle_hash LIKE '{contract_hash_hex}' "
         f"ORDER BY timestamp DESC")
 
     coin_records: list = db_bc_cursor.fetchall()
@@ -133,7 +134,7 @@ def fd_cli_cmd_nft_recover(
             'coin': {
                 'amount': coin_amount,
                 'parent_coin_info': coin_parent,
-                'puzzle_hash': contract_hash
+                'puzzle_hash': contract_hash_hex
             },
             'puzzle_reveal': program_puzzle_hex,
             'solution': coin_solution_hex


### PR DESCRIPTION
Let users supply pool contract address of NFT plot instead of manually translated version of it and translate it internally to proper representation.